### PR TITLE
Appveyor integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # go-winjob
 [![GoDoc](https://godoc.org/github.com/kolesnikovae/go-winjob?status.svg)](https://godoc.org/github.com/kolesnikovae/go-winjob/)
+[![Go Report Card](https://goreportcard.com/badge/github.com/kolesnikovae/go-winjob)](https://goreportcard.com/report/github.com/kolesnikovae/go-winjob)
+[![Build status](https://ci.appveyor.com/api/projects/status/yim6v5uws84x8ip6/branch/master?svg=true)](https://ci.appveyor.com/project/kolesnikovae/go-winjob/branch/master)
+[![CodeCov](https://codecov.io/gh/kolesnikovae/go-winjob/branch/master/graph/badge.svg)](https://codecov.io/gh/kolesnikovae/go-winjob)
 
 Go bindings for [Windows Job Objects](https://docs.microsoft.com/en-us/windows/win32/procthread/job-objects):
 > A job object allows groups of processes to be managed as a unit. Job objects are namable, securable, sharable objects that control attributes of the processes associated with them. Operations performed on a job object affect all processes associated with the job object. Examples include enforcing limits such as working set size and process priority or terminating all processes associated with a job.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,26 @@
+version: "{build}"
+
+os: Windows Server 2012 R2
+
+platform: x64
+
+clone_folder: c:\gopath\src\github.com\kolesnikovae\go-winjob
+
+environment:
+  GOVERSION: 1.14
+  GOPATH: c:\gopath
+  GO111MODULE: on
+
+build_script:
+  - cd c:\gopath\src\github.com\kolesnikovae\go-winjob
+  - git branch
+  - go get -t ./...
+
+test_script:
+  - ps: Add-AppveyorTest "Unit Tests" -Outcome Running
+  - go test -v --cover --coverprofile=coverage.txt github.com/kolesnikovae/go-winjob/...
+  - choco install codecov --yes
+  - codecov -f coverage.txt -X fix
+  - ps: Update-AppveyorTest "Unit Tests" -Outcome Passed
+
+deploy: off

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,20 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+  comment:
+    layout: "reach, diff"
+    behavior: default
+
+  coverage:
+    range: 50..80
+    round: down
+    precision: 0
+    status:
+      project:
+        default:
+          target: 80
+      patch:
+        default:
+          target: auto
+          threshold: 5

--- a/doc.go
+++ b/doc.go
@@ -1,4 +1,6 @@
-// Package go-winjob aims to provide means to manage windows job objects.
+// +build windows
+
+// Package go-winjob provides means to manage windows job objects.
 //
 // Refer to Microsoft Documentation for details: https://docs.microsoft.com/en-us/windows/win32/procthread/job-objects.
 package winjob

--- a/examples/job_object.go
+++ b/examples/job_object.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package main
 
 import (

--- a/jobapi/doc.go
+++ b/jobapi/doc.go
@@ -1,3 +1,5 @@
+// +build
+
 // Package jobapi provides supplemental types and functions for low-level
 // interactions with the operating system to control job objects.
 //


### PR DESCRIPTION
The change introduces CI unit tests. Currently, tests run on Windows Server 2012 R2 (x64) only.